### PR TITLE
Improve debugging and use LookPath

### DIFF
--- a/cmdexec/exec.go
+++ b/cmdexec/exec.go
@@ -47,8 +47,8 @@ func (c *Command) SetStdin(stdin io.Reader) {
 }
 
 // EnableDebugMode enables the debug mode for the command.
-func (c *Command) EnableDebugMode(mode bool) {
-	c.debugMode = mode
+func (c *Command) EnableDebugMode() {
+	c.debugMode = true
 }
 
 // Execute executes the command and returns the output.
@@ -60,9 +60,9 @@ func (c *Command) Execute(ctx context.Context) (*types.Result, error) {
 	}
 	res := &types.Result{Command: cmd.String()}
 	if c.debugMode {
-		res.DebugData = bytes.Buffer{}
-		cmd.Stdout = io.MultiWriter(cmd.Stdout, &res.DebugData)
-		cmd.Stderr = io.MultiWriter(cmd.Stderr, &res.DebugData)
+		res.DebugData = &bytes.Buffer{}
+		cmd.Stdout = io.MultiWriter(&res.Stdout, res.DebugData)
+		cmd.Stderr = io.MultiWriter(&res.Stderr, res.DebugData)
 	} else {
 		cmd.Stdout = &res.Stdout
 		cmd.Stderr = &res.Stderr

--- a/cmdexec/exec.go
+++ b/cmdexec/exec.go
@@ -2,6 +2,7 @@
 package cmdexec
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os/exec"
@@ -12,10 +13,11 @@ import (
 
 // Command is a command to execute.
 type Command struct {
-	Binary string // Full path to the binary to execute
-	Args   []string
-	Env    []string
-	stdin  io.Reader
+	Binary    string // Full path to the binary to execute
+	Args      []string
+	Env       []string
+	stdin     io.Reader
+	debugMode bool
 }
 
 // NewCommand creates a new command with the provided binary and arguments.
@@ -44,6 +46,11 @@ func (c *Command) SetStdin(stdin io.Reader) {
 	c.stdin = stdin
 }
 
+// EnableDebugMode enables the debug mode for the command.
+func (c *Command) EnableDebugMode(mode bool) {
+	c.debugMode = mode
+}
+
 // Execute executes the command and returns the output.
 func (c *Command) Execute(ctx context.Context) (*types.Result, error) {
 	cmd := exec.CommandContext(ctx, c.Binary, c.Args...)
@@ -52,8 +59,14 @@ func (c *Command) Execute(ctx context.Context) (*types.Result, error) {
 		cmd.Env = append(cmd.Environ(), c.Env...)
 	}
 	res := &types.Result{Command: cmd.String()}
-	cmd.Stdout = &res.Stdout
-	cmd.Stderr = &res.Stderr
+	if c.debugMode {
+		res.DebugData = bytes.Buffer{}
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, &res.DebugData)
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, &res.DebugData)
+	} else {
+		cmd.Stdout = &res.Stdout
+		cmd.Stderr = &res.Stderr
+	}
 	if c.stdin != nil {
 		cmd.Stdin = c.stdin
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/gozero
 
-go 1.21
+go 1.22
 
 require (
 	github.com/projectdiscovery/utils v0.0.55

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/gozero
 
-go 1.22
+go 1.21.0
 
 require (
 	github.com/projectdiscovery/utils v0.0.55

--- a/gozero.go
+++ b/gozero.go
@@ -3,7 +3,6 @@ package gozero
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 
 	"github.com/projectdiscovery/gozero/cmdexec"
@@ -26,7 +25,6 @@ func New(options *Options) (*Gozero, error) {
 		// this ignores path confusion issues where binary with same name exists in current path
 		fpath, err := exec.LookPath(engine)
 		if err != nil {
-			fmt.Printf("engine %s not found: %v\n", engine, err)
 			continue
 		} else {
 			options.engine = fpath
@@ -53,6 +51,9 @@ func (g *Gozero) Eval(ctx context.Context, src, input *Source, args ...string) (
 	if err != nil {
 		// returns error if binary(engine) does not exist
 		return nil, err
+	}
+	if g.Options.DebugMode {
+		gcmd.EnableDebugMode()
 	}
 	gcmd.SetStdin(input.File) // stdin
 	// add both input and src variables if any

--- a/gozero.go
+++ b/gozero.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"os/exec"
-	"time"
 
 	"github.com/projectdiscovery/gozero/cmdexec"
 	"github.com/projectdiscovery/gozero/types"
-	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 // Gozero is executor for gozero
@@ -20,13 +18,12 @@ type Gozero struct {
 func New(options *Options) (*Gozero, error) {
 	// attempt to locate the interpreter by executing it
 	for _, engine := range options.Engines {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		cmd := exec.CommandContext(ctx, engine)
-		err := cmd.Run()
-		if err == nil || errorutil.IsAny(err, exec.ErrWaitDelay) {
-			options.engine = engine
+		// use lookpath to check if engine is available
+		// this ignores path confusion issues where binary with same name exists in current path
+		_, err := exec.LookPath(engine)
+		if err != nil {
+			continue
+		} else {
 			break
 		}
 	}

--- a/gozero.go
+++ b/gozero.go
@@ -3,6 +3,7 @@ package gozero
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 
 	"github.com/projectdiscovery/gozero/cmdexec"
@@ -16,14 +17,19 @@ type Gozero struct {
 
 // New creates a new gozero executor
 func New(options *Options) (*Gozero, error) {
+	if len(options.Engines) == 0 {
+		return nil, errors.New("no engines provided")
+	}
 	// attempt to locate the interpreter by executing it
 	for _, engine := range options.Engines {
 		// use lookpath to check if engine is available
 		// this ignores path confusion issues where binary with same name exists in current path
-		_, err := exec.LookPath(engine)
+		fpath, err := exec.LookPath(engine)
 		if err != nil {
+			fmt.Printf("engine %s not found: %v\n", engine, err)
 			continue
 		} else {
+			options.engine = fpath
 			break
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -7,4 +7,7 @@ type Options struct {
 	PreferStartProcess       bool
 	Sandbox                  bool
 	EarlyCloseFileDescriptor bool
+	// When Debug Mode is set to true, Output result will contain
+	// more debug information
+	DebugMode bool
 }

--- a/source.go
+++ b/source.go
@@ -70,7 +70,6 @@ func (s *Source) Close() error {
 	if s.File != nil {
 		return s.File.Close()
 	}
-
 	return nil
 }
 
@@ -78,12 +77,10 @@ func (s *Source) Cleanup() error {
 	if err := s.Close(); err != nil {
 		return err
 	}
-
 	if s.Temporary {
 		return os.RemoveAll(s.Filename)
 	}
-
-	return errors.New("no cleanup needed")
+	return nil
 }
 
 func (s *Source) ReadAll() ([]byte, error) {

--- a/source_test.go
+++ b/source_test.go
@@ -65,7 +65,11 @@ func TestNewSourceWithReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create new source with reader: %v", err)
 	}
-	defer source.Cleanup()
+	defer func() {
+		if err := source.Cleanup(); err != nil {
+			t.Errorf("Failed to cleanup new source with reader: %v", err)
+		}
+	}()
 
 	if !source.Temporary {
 		t.Error("Expected source to be marked as temporary")

--- a/types/result.go
+++ b/types/result.go
@@ -12,10 +12,11 @@ import (
 
 // Result contains the result of a command execution.
 type Result struct {
-	Command string // Include final command that was executed
-	Stdout  bytes.Buffer
-	Stderr  bytes.Buffer
-	exitErr *exec.ExitError // return exit error this includes exit code , command sysusage and more
+	Command   string // Include final command that was executed
+	Stdout    bytes.Buffer
+	Stderr    bytes.Buffer
+	exitErr   *exec.ExitError // return exit error this includes exit code , command sysusage and more
+	DebugData bytes.Buffer    // only available when debug mode is enabled
 }
 
 // GetExitError returns the exit error if any.

--- a/types/result.go
+++ b/types/result.go
@@ -16,7 +16,7 @@ type Result struct {
 	Stdout    bytes.Buffer
 	Stderr    bytes.Buffer
 	exitErr   *exec.ExitError // return exit error this includes exit code , command sysusage and more
-	DebugData bytes.Buffer    // only available when debug mode is enabled
+	DebugData *bytes.Buffer   // only available when debug mode is enabled
 }
 
 // GetExitError returns the exit error if any.


### PR DESCRIPTION
## Proposed Changes

- Use LookPath for locating and initializing binaries ( it is not intrusive way to validate existance of a command )
- earlier we used to execute command directly with 1 sec timeout for validating engine which could be the reason behind the flakiness observed in powershell engines and windows env in general
- Added hooks and extra debug mode to dump combined stdout + stderr 
- upstream PR https://github.com/projectdiscovery/nuclei/pull/5767

>[!NOTE]
> Apart from slight intrusive methodology , Nuclei in windows environment was sometimes returning `powershell.exe` engine not found randomly due to exec behaviour with 1 sec timeout (go in windows is know to be very slow, and this box in particular had less compute) , by switching to LookPath this issue was resolved and template loading time is stable and faster in windows especially with low spec